### PR TITLE
Simplify `generateHash` method.

### DIFF
--- a/src/SensioLabs/Melody/WorkingDirectory/WorkingDirectoryFactory.php
+++ b/src/SensioLabs/Melody/WorkingDirectory/WorkingDirectoryFactory.php
@@ -34,10 +34,8 @@ class WorkingDirectoryFactory
 
     private function generateHash(array $packages)
     {
-        $copy = $packages;
+        ksort($packages);
 
-        ksort($copy);
-
-        return hash('sha256', serialize($copy));
+        return hash('sha256', serialize($packages));
     }
 }


### PR DESCRIPTION
Arrays are passed by value, so no need to create a copy
