### PR TITLE
Improve permission handling when using self-update

### DIFF
--- a/src/SensioLabs/Melody/Console/Application.php
+++ b/src/SensioLabs/Melody/Console/Application.php
@@ -55,7 +55,9 @@ class Application extends BaseApplication
         $commands = parent::getDefaultCommands();
 
         $commands[] = new RunCommand();
-        $commands[] = new SelfUpdateCommand();
+        if (\Phar::running()) {
+            $commands[] = new SelfUpdateCommand();
+        }
 
         return $commands;
     }


### PR DESCRIPTION
I replace the `file_get_content` by a `@copy + file_exists` to avoid to download the file twice.
I replace the rename by a `file_put_content` in case we have permission on the file and not on the directory
I detect common permission errors before starting the download

Fixes #5
