### PR TITLE
Simplify install command

### DIFF
--- a/doc/install.md
+++ b/doc/install.md
@@ -12,16 +12,6 @@ Globally (manual)
 
 You can run these commands to easily access melody from anywhere on your system:
 
-
-    $ sudo wget http://get.sensiolabs.org/melody.phar -O /usr/local/bin/melody
-
-or with curl:
-
-
-    $ sudo curl http://get.sensiolabs.org/melody.phar -o /usr/local/bin/melody
-
-then:
-
-    $ sudo chmod a+x /usr/local/bin/melody
+    $ sudo sh -c "curl http://get.sensiolabs.org/melody.phar -o /usr/local/bin/melody && chmod a+x /usr/local/bin/melody"
 
 Then, just run `melody`


### PR DESCRIPTION
Remove `curl` syntax. Because, IMHO, one command is enought. and a user who don't have `wget` knows how to replace it by his favorite command.

Install in one line (merge `wget` anf `chmod` on the same command)
