### PR TITLE
Remove blank line in remote template

### DIFF
--- a/src/SensioLabs/Melody/Runner/Runner.php
+++ b/src/SensioLabs/Melody/Runner/Runner.php
@@ -69,9 +69,7 @@ TEMPLATE;
     {
         $template = <<<TEMPLATE
 {{ head }}
-?>
-
-{{ code }}
+?>{{ code }}
 
 TEMPLATE;
 


### PR DESCRIPTION
Actualy, when melody ran a Gist file, it display a (not desired) blank line.
This PR remove this blank line.
