### PR TITLE
Php options

### DIFF
--- a/doc/features.md
+++ b/doc/features.md
@@ -77,3 +77,33 @@ melody will catch them. To use options, you must prepend your options by ` -- `.
 ```bash
 $ php melody.phar run test.php -- -a -arg1 arg2
 ```
+
+Front matter
+------------
+
+The script you want to run with melody **must** starts with a YAML configuration
+embeded in a `heredoc` string named `CONFIG`. This config must contains at least one
+package to install.
+
+You can also provide a list of options to pass to php command. it could be
+usefull to start a php web server.
+
+```php
+<?php
+<<<CONFIG
+packages:
+    - silex/silex
+php-options:
+    - "-S"
+    - "localhost:8000"
+CONFIG;
+$app = new Silex\Application();
+$app->get('/hello/{name}', function ($name) use ($app) {
+    return 'Hello '.$app->escape($name);
+});
+$app->run();
+```
+
+Beware of YAML syntax:
+* `- silex/silex: ~1.2` without double quote is an invalid YAML
+* `- -S` without double quote is an array of arrays

--- a/src/SensioLabs/Melody/Configuration/ConfigurationParser.php
+++ b/src/SensioLabs/Melody/Configuration/ConfigurationParser.php
@@ -21,8 +21,9 @@ class ConfigurationParser
         }
 
         $packages = $this->parsePackages($config);
+        $phpOptions = $this->parsePhpOptions($config);
 
-        return new ScriptConfiguration($packages);
+        return new ScriptConfiguration($packages, $phpOptions);
     }
 
     private function parsePackages($config)
@@ -32,7 +33,7 @@ class ConfigurationParser
         }
 
         if (!is_array($config['packages'])) {
-            throw new ParseException('Packages configuration should be an array.');
+            throw new ParseException('The packages configuration should be an array.');
         }
 
         $packages = array();
@@ -87,4 +88,26 @@ class ConfigurationParser
         return trim($package);
     }
 
+    private function parsePhpOptions($config)
+    {
+        if (!array_key_exists('php-options', $config)) {
+            return array();
+        }
+
+        if (!is_array($config['php-options'])) {
+            throw new ParseException('The php-options configuration should be an array.');
+        }
+
+        $phpOptions = array();
+
+        foreach ($config['php-options'] as $i => $phpOption) {
+            if (!is_string($phpOption)) {
+                throw new ParseException(sprintf('The php-option at key "%s" should be a string.', $i));
+            }
+
+            $phpOptions[] = $phpOption;
+        }
+
+        return $phpOptions;
+    }
 }

--- a/src/SensioLabs/Melody/Configuration/ScriptConfiguration.php
+++ b/src/SensioLabs/Melody/Configuration/ScriptConfiguration.php
@@ -10,14 +10,21 @@ namespace SensioLabs\Melody\Configuration;
 class ScriptConfiguration
 {
     private $packages;
+    private $phpOptions;
 
-    public function __construct(array $packages)
+    public function __construct(array $packages, array $phpOptions)
     {
         $this->packages = $packages;
+        $this->phpOptions = $phpOptions;
     }
 
     public function getPackages()
     {
         return $this->packages;
+    }
+
+    public function getPhpOptions()
+    {
+        return $this->phpOptions;
     }
 }

--- a/src/SensioLabs/Melody/Runner/Runner.php
+++ b/src/SensioLabs/Melody/Runner/Runner.php
@@ -39,6 +39,7 @@ class Runner
         $process = ProcessBuilder::create(array_merge(
             array($phpFinder->find(false)),
             $phpFinder->findArguments(),
+            $script->getConfiguration()->getPhpOptions(),
             array($file),
             $script->getArguments()
         ))->getProcess();

--- a/src/SensioLabs/Melody/Tests/Integration/php-options.php
+++ b/src/SensioLabs/Melody/Tests/Integration/php-options.php
@@ -1,0 +1,9 @@
+<?php
+<<<CONFIG
+packages:
+    - "twig/twig:1.16.0"
+php-options:
+    - "-d memory_limit=42M"
+CONFIG;
+
+echo ini_get('memory_limit');

--- a/src/SensioLabs/Melody/Tests/IntegrationTest.php
+++ b/src/SensioLabs/Melody/Tests/IntegrationTest.php
@@ -59,6 +59,12 @@ class IntegrationTest extends \PHPUnit_Framework_TestCase
         $this->assertContains('value', $output);
     }
 
+    public function testRunWithPhpOptions()
+    {
+        $output = $this->melodyRun('php-options.php');
+        $this->assertContains('42M', $output);
+    }
+
     private function melodyRun($fixture, array $options = array())
     {
         $melody = new Melody();


### PR DESCRIPTION
With this PR, you can pass options to the php command. For instance, you can pass "-S 127.0.0.1:8000" and starting a new Web Server.

``` php
<?php
<<<CONFIG
packages:
    - silex/silex
php-options:
    - "-S"
    - "localhost:8000"
CONFIG;
$app = new Silex\Application();
$app->get('/hello/{name}', function ($name) use ($app) {
    return 'Hello '.$app->escape($name);
});
$app->run();
```

You can test it with `melody run b217329b2c349c460b74 -vvv`
