### PR TITLE
Fix bug and tests on HHVM

### DIFF
--- a/src/SensioLabs/Melody/Console/Application.php
+++ b/src/SensioLabs/Melody/Console/Application.php
@@ -53,7 +53,7 @@ class Application extends BaseApplication
         $commands = parent::getDefaultCommands();
 
         $commands[] = new RunCommand();
-        if (\Phar::running()) {
+        if (0 === stripos(__FILE__, 'phar://')) {
             $commands[] = new SelfUpdateCommand();
         }
 

--- a/src/SensioLabs/Melody/Runner/Runner.php
+++ b/src/SensioLabs/Melody/Runner/Runner.php
@@ -40,8 +40,8 @@ class Runner
 
         $process = ProcessBuilder::create(array_merge(
             array($phpFinder->find(false)),
-            $phpFinder->findArguments(),
             $script->getConfiguration()->getPhpOptions(),
+            $phpFinder->findArguments(),
             array($file),
             $script->getArguments()
         ))->getProcess();

--- a/src/SensioLabs/Melody/Tests/Integration/php-options.php
+++ b/src/SensioLabs/Melody/Tests/Integration/php-options.php
@@ -6,4 +6,4 @@ php-options:
     - "-d memory_limit=42M"
 CONFIG;
 
-echo ini_get('memory_limit');
+echo sprintf('memory_limit=%s', ini_get('memory_limit'));

--- a/src/SensioLabs/Melody/Tests/IntegrationTest.php
+++ b/src/SensioLabs/Melody/Tests/IntegrationTest.php
@@ -62,7 +62,7 @@ class IntegrationTest extends \PHPUnit_Framework_TestCase
     public function testRunWithPhpOptions()
     {
         $output = $this->melodyRun('php-options.php');
-        $this->assertContains('42M', $output);
+        $this->assertContains('memory_limit=42M', $output);
     }
 
     private function melodyRun($fixture, array $options = array())


### PR DESCRIPTION
Also replace `\Phar::running()` by `0 === stripos(__FILE__, 'phar://')`
because it's not supported in hhvm: http://docs.hhvm.com/manual/en/phar.running.php
