### PR TITLE
Allow script who dont starts with <?php

### DIFF
--- a/src/SensioLabs/Melody/Resource/ResourceParser.php
+++ b/src/SensioLabs/Melody/Resource/ResourceParser.php
@@ -15,7 +15,7 @@ class ResourceParser
 {
     public function parseResource(Resource $resource)
     {
-        preg_match('{^<\?php\s*<<<CONFIG(?P<config>.+)CONFIG;(?P<code>.+)$}sU', $resource->getContent(), $matches);
+        preg_match('{^(?:#![^\n]+\n)?<\?php\s*<<<CONFIG(?P<config>.+)CONFIG;(?P<code>.+)$}sU', $resource->getContent(), $matches);
 
         if (!$matches) {
             throw new ParseException('Impossible to parse the content of the document.');

--- a/src/SensioLabs/Melody/Tests/Integration/shebang.php
+++ b/src/SensioLabs/Melody/Tests/Integration/shebang.php
@@ -1,0 +1,13 @@
+#!/usr/local/bin/melody run
+<?php
+<<<CONFIG
+packages:
+    - "twig/twig:1.16.0"
+CONFIG;
+
+$twig = new Twig_Environment(new Twig_Loader_Array(array(
+    'foo' => 'Hello {{ include("bar") }}',
+    'bar' => 'world'
+)));
+
+echo $twig->render('foo');

--- a/src/SensioLabs/Melody/Tests/IntegrationTest.php
+++ b/src/SensioLabs/Melody/Tests/IntegrationTest.php
@@ -32,6 +32,15 @@ class IntegrationTest extends \PHPUnit_Framework_TestCase
         $this->assertContains('Hello world', $output);
     }
 
+    public function testRunWithShebang()
+    {
+        $output = $this->melodyRun('shebang.php');
+        $this->assertContains('Loading composer repositories with package information', $output);
+        $this->assertContains('Updating dependencies (including require-dev)', $output);
+        $this->assertContains('Installing twig/twig (v1.16.0)', $output);
+        $this->assertContains('Hello world', $output);
+    }
+
     public function testRunWithCache()
     {
         $this->melodyRun('hello-world.php');


### PR DESCRIPTION
The main purpose, is to allow a shebang as in the follwing script

```
#!/usr/local/bin/melody run
<?php

<<<CONFIG
packages:
    - "twig/twig: ~1.0"
CONFIG;

$loader = new Twig_Loader_Array(array(
    'index' => "Hello {{ name }}!\n",
));

$twig = new Twig_Environment($loader);
echo $twig->render('index', array('name' => 'Melody'));
```
