### PR TITLE
Improve guessComposerPath

### DIFF
--- a/src/SensioLabs/Melody/Composer/Composer.php
+++ b/src/SensioLabs/Melody/Composer/Composer.php
@@ -3,33 +3,35 @@
 namespace SensioLabs\Melody\Composer;
 
 use Symfony\Component\Process\ExecutableFinder;
+use Symfony\Component\Process\PhpExecutableFinder;
 use Symfony\Component\Process\ProcessBuilder;
 
 /**
  * Composer
  *
  * @author Grégoire Pineau <lyrixx@lyrixx.info>
+ * @author Jérémy Derussé <jeremy@derusse.com>
  */
 class Composer
 {
-    public function __construct($composerPath = null)
+    public function __construct(array $composerCommand = null)
     {
-        if (!$composerPath) {
-            $composerPath = $this->guessComposerPath();
+        if (!$composerCommand) {
+            $composerCommand = $this->guessComposerCommand();
         }
 
-        if (!$composerPath) {
+        if (!$composerCommand) {
             throw new \RuntimeException('Impossible to find composer executable.');
         }
 
-        $this->composerPath = $composerPath;
+        $this->composerCommand = $composerCommand;
     }
 
     public function buildProcess(array $packages, $dir, $preferSource = false)
     {
-        $args = array(
-            $this->composerPath,
-            'require',
+        $args = array_merge(
+            $this->composerCommand,
+            array('require')
         );
 
         foreach ($packages as $package => $version) {
@@ -53,11 +55,13 @@ class Composer
 
     public function getVendorDir()
     {
-        $args = array(
-            $this->composerPath,
-            'config',
-            '--global',
-            'vendor-dir',
+        $args = array_merge(
+            $this->composerCommand,
+            array(
+                'config',
+                '--global',
+                'vendor-dir',
+            )
         );
 
         $process = ProcessBuilder::create($args)
@@ -75,11 +79,38 @@ class Composer
         return end($outputByLines);
     }
 
-    private function guessComposerPath()
+    /**
+     * Guess and build the command to call composer.
+     *
+     * Search:
+     *  - a executable composer (or composer.phar)
+     *  - a file composer (or composer.phar) prefixed by php
+     */
+    private function guessComposerCommand()
     {
-        $finder = new ExecutableFinder();
-        $finder->addSuffix('.phar');
+        $candidateNames = array('composer', 'composer.phar');
 
-        return $finder->find('composer');
+        $executableFinder = new ExecutableFinder();
+        foreach ($candidateNames as $candidateName) {
+            if ($composerPath = $executableFinder->find($candidateName, null, array(getcwd()))) {
+                return array($composerPath);
+            }
+        }
+
+        foreach ($candidateNames as $candidateName) {
+            $composerPath = sprintf('%s/%s', getcwd(), $candidateName);
+            if (file_exists($composerPath)) {
+                $phpFinder = new PhpExecutableFinder();
+                return array_merge(
+                    array(
+                        $phpFinder->find(false),
+                        $composerPath
+                    ),
+                    $phpFinder->findArguments()
+                );
+            }
+        }
+
+        return null;
     }
 }


### PR DESCRIPTION
Given the `ExecutableFinder` can not search for a given extension (https://github.com/symfony/symfony/issues/12247). 

I refactor the method `guessComposer` to search for executable with or without extension `.phar` and to also provide a command prefixed by PHP in case of file `composer` exists and is not executable.
