### PR TITLE
refactor melody pattern into a global const to ease re-use

### DIFF
--- a/src/SensioLabs/Melody/Resource/ResourceParser.php
+++ b/src/SensioLabs/Melody/Resource/ResourceParser.php
@@ -13,9 +13,11 @@ use Symfony\Component\Yaml\Yaml;
  */
 class ResourceParser
 {
+    const MELODY_PATTERN = '{^(?:#![^\n]+\n)?<\?php\s*<<<CONFIG(?P<config>.+)CONFIG;(?P<code>.+)$}sU';
+    
     public function parseResource(Resource $resource)
     {
-        preg_match('{^(?:#![^\n]+\n)?<\?php\s*<<<CONFIG(?P<config>.+)CONFIG;(?P<code>.+)$}sU', $resource->getContent(), $matches);
+        preg_match(self::MELODY_PATTERN, $resource->getContent(), $matches);
 
         if (!$matches) {
             throw new ParseException('Impossible to parse the content of the document.');


### PR DESCRIPTION
I would like to use the pattern to detect melody-style scripts before passing them over to melody.

An alternative implemenation could also be adding a new api.method which checks a source-string for the pattern, instead of publishing the pattern itself.