### PR TITLE
search only for the bootstrap-files on garbage collection

### DIFF
--- a/src/SensioLabs/Melody/WorkingDirectory/GarbageCollector.php
+++ b/src/SensioLabs/Melody/WorkingDirectory/GarbageCollector.php
@@ -35,6 +35,7 @@ class GarbageCollector
         $maxATime = time() - self::TTL;
 
         $files = Finder::create()
+            ->files()
             ->in($this->storePath)
             ->depth(1)
             ->name(Runner::BOOTSTRAP_FILENAME)


### PR DESCRIPTION
We don't wanne match a equal named directory. Might also speedup things a bit.