### PR TITLE
GC: Also take files within the root of the storagePath into account

### DIFF
--- a/src/SensioLabs/Melody/WorkingDirectory/GarbageCollector.php
+++ b/src/SensioLabs/Melody/WorkingDirectory/GarbageCollector.php
@@ -34,7 +34,7 @@ class GarbageCollector
     {
         $maxATime = time() - self::TTL;
 
-        $files = Finder::create()
+        $bootstrapFiles = Finder::create()
             ->in($this->storePath)
             ->depth(1)
             ->name(Runner::BOOTSTRAP_FILENAME)
@@ -44,11 +44,21 @@ class GarbageCollector
         ;
 
         $directories = array();
-
-        foreach ($files as $file) {
+        foreach ($bootstrapFiles as $file) {
             $directories[] = dirname($file);
         }
 
         $this->filesystem->remove($directories);
+        
+        $rootFiles = Finder::create()
+            ->files()
+            ->in($this->storePath)
+            ->depth(0)
+            ->filter(function (SplFileInfo $d) use ($maxATime) {
+                return $d->getATime() < $maxATime;
+            })
+        ;
+        
+        $this->filesystem->remove($rootFiles);
     }
 }


### PR DESCRIPTION
before only directories were cleaned up, which contained a `Runner::BOOTSTRAP_FILENAME`.
with this change, also files within the toplevel of `storagePath` are deleted, when older then `GarbageCollector::TTL`