### PR TITLE
Stop execution when underlying composer commands fail

### DIFF
--- a/src/SensioLabs/Melody/Melody.php
+++ b/src/SensioLabs/Melody/Melody.php
@@ -63,6 +63,11 @@ class Melody
             $process = $this->composer->buildProcess($script->getPackages(), $workingDirectory->getPath(), $configuration->preferSource());
 
             $cliExecutor($process, true);
+            
+            // errors were already sent by the cliExecutor, just stop further processing
+            if ($process->getExitCode() !== 0) {
+                return;
+            }
 
             $workingDirectory->lock();
         }


### PR DESCRIPTION
A melody script requires a proper initialized environment, including all
its dependencies. When a composer command errors, let the `cliExecutor` do
the output and stop further processing.

Otherwise we will trigger most likely only subsequent errors.
This also makes sure that the working directory will be re-initialised on next run instead of leaving it in a inconsistent state.