### PR TITLE
Prefix the working directory hash to avoid weird issue

### DIFF
--- a/src/SensioLabs/Melody/WorkingDirectory/WorkingDirectoryFactory.php
+++ b/src/SensioLabs/Melody/WorkingDirectory/WorkingDirectoryFactory.php
@@ -36,6 +36,9 @@ class WorkingDirectoryFactory
     {
         ksort($packages);
 
-        return hash('sha256', serialize($packages));
+        // Some application use `basename(__DIR__)` and may generate class
+        // name with this dirname. And a sha256 hash may start with a number.
+        // This will lead to a fatal error because PHP forbid that.
+        return 'a'.hash('sha256', serialize($packages));
     }
 }


### PR DESCRIPTION
Some application use `basename(__DIR__)` and may generate class name with this
dirname. And a sha256 hash may start with a number. This will lead to a fatal
error because PHP forbid that.

see https://github.com/symfony/symfony/pull/13412 for a related issue