### PR TITLE
Prevent errors regarding tty when melody is run from web-context

### DIFF
--- a/src/SensioLabs/Melody/Runner/Runner.php
+++ b/src/SensioLabs/Melody/Runner/Runner.php
@@ -46,7 +46,7 @@ class Runner
             $script->getArguments()
         ))->getProcess();
 
-        if (!defined('PHP_WINDOWS_VERSION_BUILD')) {
+        if (!defined('PHP_WINDOWS_VERSION_BUILD') && php_sapi_name() === 'cli') {
             $process->setTty(true);
         }
 


### PR DESCRIPTION
setTty() issues a error because the webserver has no permission to
access `/dev/tty` (tested on ubuntu 12)