### PR TITLE
Make errors visible

### DIFF
--- a/src/SensioLabs/Melody/Runner/Runner.php
+++ b/src/SensioLabs/Melody/Runner/Runner.php
@@ -96,7 +96,7 @@ require __DIR__.'/{{ vendorDir }}/autoload.php';
 
 // Error handling part
 error_reporting(-1);
-ini_set('display_errors', 0);
+ini_set('display_errors', 1);
 set_error_handler(function ($level, $message, $file = 'unknown', $line = 0, $context = array()) {
     $message = sprintf('%s: %s in %s line %d', $level, $message, $file, $line);
 


### PR DESCRIPTION
It's quite a pain that errors aren't shown in melody scripts. Fatal errors are hidden and errors converted to exceptions also also result in empty output.