### PR TITLE
Access Gists from behind a HTTP proxy

### DIFF
--- a/doc/features.md
+++ b/doc/features.md
@@ -21,6 +21,9 @@ Supported formats:
 Please note that `melody` can only handle gists which contain a single PHP
 file. It will report an error otherwise.
 
+For those users behind a proxy server, `melody` now uses the `HTTPS_PROXY`
+environment variable.
+
 Run streamed script
 -------------------
 

--- a/src/SensioLabs/Melody/Handler/Github/Gist.php
+++ b/src/SensioLabs/Melody/Handler/Github/Gist.php
@@ -49,6 +49,7 @@ class Gist
     public function download()
     {
         $handle = curl_init();
+        $http_proxy = filter_input(INPUT_ENV, 'HTTPS_PROXY', FILTER_SANITIZE_URL);
 
         curl_setopt_array($handle, array(
             CURLOPT_URL            => sprintf('https://api.github.com/gists/%s', $this->id),
@@ -58,6 +59,10 @@ class Gist
             ),
             CURLOPT_RETURNTRANSFER => 1,
         ));
+
+        if ($http_proxy) {
+            curl_setopt($handle, CURLOPT_PROXY, $http_proxy);
+        }
 
         $content = curl_exec($handle);
         curl_close($handle);


### PR DESCRIPTION
Hi @lyrixx,

I've now successfully built and used melody on a Gist from behind our proxy server. I've added a note in [the features documentation](/sensiolabs/melody/blob/master/doc/features.md#run-gists-scripts).

Also, the existing test suite still completes OK.

Please pull when you have a chance.

Best wishes,


Nick