### PR TITLE
[new-feature] Can require php version or extensions

### DIFF
--- a/src/SensioLabs/Melody/Configuration/ConfigurationParser.php
+++ b/src/SensioLabs/Melody/Configuration/ConfigurationParser.php
@@ -12,7 +12,7 @@ use SensioLabs\Melody\Exception\ParseException;
 class ConfigurationParser
 {
     const PACKAGE_DELIMITER = ':';
-    const PACKAGE_REGEX = '/^((|[a-zA-Z0-9]([_.-]?[a-zA-Z0-9]+)*\\/[a-zA-Z0-9]([_.-]?[a-zA-Z0-9]+)*)|php|ext-[a-zA-Z0-9_.-]*)$/';
+    const PACKAGE_REGEX = '/^((|[a-zA-Z0-9]([_.-]?[a-zA-Z0-9]+)*\\/[a-zA-Z0-9]([_.-]?[a-zA-Z0-9]+)*)|php|ext-[a-zA-Z0-9_.-]+)$/';
 
     public function parseConfiguration($config)
     {

--- a/src/SensioLabs/Melody/Configuration/ConfigurationParser.php
+++ b/src/SensioLabs/Melody/Configuration/ConfigurationParser.php
@@ -12,7 +12,7 @@ use SensioLabs\Melody\Exception\ParseException;
 class ConfigurationParser
 {
     const PACKAGE_DELIMITER = ':';
-    const PACKAGE_REGEX = '/^(|[a-zA-Z0-9]([_.-]?[a-zA-Z0-9]+)*\\/[a-zA-Z0-9]([_.-]?[a-zA-Z0-9]+)*)$/';
+    const PACKAGE_REGEX = '/^((|[a-zA-Z0-9]([_.-]?[a-zA-Z0-9]+)*\\/[a-zA-Z0-9]([_.-]?[a-zA-Z0-9]+)*)|php|ext-[a-zA-Z0-9_.-]*)$/';
 
     public function parseConfiguration($config)
     {

--- a/src/SensioLabs/Melody/Tests/Configuration/ConfigurationParserTest.php
+++ b/src/SensioLabs/Melody/Tests/Configuration/ConfigurationParserTest.php
@@ -48,6 +48,8 @@ class ConfigurationParserTest extends \PHPUnit_Framework_TestCase
             'symfony/console: 1.2',
             'symfony/filesystem',
             'symfony/filesystem: 1.3',
+            'php: 5.5.0',
+            'ext-pdo: *',
         )));
 
         $this->assertInstanceOf('SensioLabs\Melody\Configuration\ScriptConfiguration', $config);
@@ -55,6 +57,8 @@ class ConfigurationParserTest extends \PHPUnit_Framework_TestCase
             'symfony/finder' => '*',
             'symfony/console' => '1.2',
             'symfony/filesystem' => '1.3',
+            'php' => '5.5.0',
+            'ext-pdo' => '*',
         );
         $this->assertSame($expected, $config->getPackages());
     }

--- a/src/SensioLabs/Melody/Tests/Integration/hello-world-with-constraints.php
+++ b/src/SensioLabs/Melody/Tests/Integration/hello-world-with-constraints.php
@@ -1,0 +1,14 @@
+<?php
+<<<CONFIG
+packages:
+    - "twig/twig:1.16.0"
+    - "php: >=5.3.0"
+    - "ext-pdo: *"
+CONFIG;
+
+$twig = new Twig_Environment(new Twig_Loader_Array(array(
+    'foo' => 'Hello {{ include("bar") }}',
+    'bar' => 'world'
+)));
+
+echo $twig->render('foo');

--- a/src/SensioLabs/Melody/Tests/IntegrationTest.php
+++ b/src/SensioLabs/Melody/Tests/IntegrationTest.php
@@ -11,6 +11,18 @@ class IntegrationTest extends \PHPUnit_Framework_TestCase
 {
     private $fs;
 
+    protected function setUp()
+    {
+        $this->fs = new Filesystem();
+        $this->cleanCache();
+    }
+
+    protected function tearDown()
+    {
+        $this->cleanCache();
+        $this->fs = null;
+    }
+
     public function testRunWithDefaultOption()
     {
         $output = $this->melodyRun('hello-world.php');
@@ -18,37 +30,6 @@ class IntegrationTest extends \PHPUnit_Framework_TestCase
         $this->assertContains('Updating dependencies (including require-dev)', $output);
         $this->assertContains('Installing twig/twig (v1.16.0)', $output);
         $this->assertContains('Hello world', $output);
-    }
-
-    private function melodyRun($fixture, array $options = array())
-    {
-        $melody = new Melody();
-
-        $filename = $this->getFixtureFile($fixture);
-
-        $options = array_replace(array(
-            'prefer_source' => false,
-            'no_cache' => false,
-        ), $options);
-
-        $configuration = new RunConfiguration($options['no_cache'], $options['prefer_source']);
-
-        $output = null;
-        $cliExecutor = function (Process $process, $useProcessHelper) use (&$output) {
-            $process->setTty(false);
-            $process->mustRun(function ($type, $text) use (&$output) {
-                $output .= $text;
-            });
-        };
-
-        $melody->run($filename, array(), $configuration, $cliExecutor);
-
-        return $output;
-    }
-
-    private function getFixtureFile($fixtureName)
-    {
-        return sprintf('%s/Integration/%s', __DIR__, $fixtureName);
     }
 
     public function testRunWithShebang()
@@ -144,10 +125,30 @@ class IntegrationTest extends \PHPUnit_Framework_TestCase
         $this->assertContains('memory_limit=42M', $output);
     }
 
-    protected function setUp()
+    private function melodyRun($fixture, array $options = array())
     {
-        $this->fs = new Filesystem();
-        $this->cleanCache();
+        $melody = new Melody();
+
+        $filename = $this->getFixtureFile($fixture);
+
+        $options = array_replace(array(
+            'prefer_source' => false,
+            'no_cache' => false,
+        ), $options);
+
+        $configuration = new RunConfiguration($options['no_cache'], $options['prefer_source']);
+
+        $output = null;
+        $cliExecutor = function (Process $process, $useProcessHelper) use (&$output) {
+            $process->setTty(false);
+            $process->mustRun(function ($type, $text) use (&$output) {
+                $output .= $text;
+            });
+        };
+
+        $melody->run($filename, array(), $configuration, $cliExecutor);
+
+        return $output;
     }
 
     private function cleanCache()
@@ -155,9 +156,8 @@ class IntegrationTest extends \PHPUnit_Framework_TestCase
         $this->fs->remove(sys_get_temp_dir() . '/melody');
     }
 
-    protected function tearDown()
+    private function getFixtureFile($fixtureName)
     {
-        $this->cleanCache();
-        $this->fs = null;
+        return sprintf('%s/Integration/%s', __DIR__, $fixtureName);
     }
 }

--- a/src/SensioLabs/Melody/Tests/IntegrationTest.php
+++ b/src/SensioLabs/Melody/Tests/IntegrationTest.php
@@ -152,7 +152,7 @@ class IntegrationTest extends \PHPUnit_Framework_TestCase
 
     private function cleanCache()
     {
-        $this->fs->remove(sys_get_temp_dir() . '/melody');
+        $this->fs->remove(sys_get_temp_dir().'/melody');
     }
 
     private function getFixtureFile($fixtureName)

--- a/src/SensioLabs/Melody/Tests/IntegrationTest.php
+++ b/src/SensioLabs/Melody/Tests/IntegrationTest.php
@@ -45,7 +45,7 @@ class IntegrationTest extends \PHPUnit_Framework_TestCase
     {
         $this->melodyRun('hello-world.php');
         $output = $this->melodyRun('hello-world.php');
-        $this->assertSame('Hello world', $output);
+        $this->assertContains('Hello world', $output);
     }
 
     public function testRunWithConstraints()

--- a/src/SensioLabs/Melody/Tests/IntegrationTest.php
+++ b/src/SensioLabs/Melody/Tests/IntegrationTest.php
@@ -11,18 +11,6 @@ class IntegrationTest extends \PHPUnit_Framework_TestCase
 {
     private $fs;
 
-    protected function setUp()
-    {
-        $this->fs = new Filesystem();
-        $this->cleanCache();
-    }
-
-    protected function tearDown()
-    {
-        $this->cleanCache();
-        $this->fs = null;
-    }
-
     public function testRunWithDefaultOption()
     {
         $output = $this->melodyRun('hello-world.php');
@@ -30,6 +18,37 @@ class IntegrationTest extends \PHPUnit_Framework_TestCase
         $this->assertContains('Updating dependencies (including require-dev)', $output);
         $this->assertContains('Installing twig/twig (v1.16.0)', $output);
         $this->assertContains('Hello world', $output);
+    }
+
+    private function melodyRun($fixture, array $options = array())
+    {
+        $melody = new Melody();
+
+        $filename = $this->getFixtureFile($fixture);
+
+        $options = array_replace(array(
+            'prefer_source' => false,
+            'no_cache' => false,
+        ), $options);
+
+        $configuration = new RunConfiguration($options['no_cache'], $options['prefer_source']);
+
+        $output = null;
+        $cliExecutor = function (Process $process, $useProcessHelper) use (&$output) {
+            $process->setTty(false);
+            $process->mustRun(function ($type, $text) use (&$output) {
+                $output .= $text;
+            });
+        };
+
+        $melody->run($filename, array(), $configuration, $cliExecutor);
+
+        return $output;
+    }
+
+    private function getFixtureFile($fixtureName)
+    {
+        return sprintf('%s/Integration/%s', __DIR__, $fixtureName);
     }
 
     public function testRunWithShebang()
@@ -45,6 +64,13 @@ class IntegrationTest extends \PHPUnit_Framework_TestCase
     {
         $this->melodyRun('hello-world.php');
         $output = $this->melodyRun('hello-world.php');
+        $this->assertSame('Hello world', $output);
+    }
+
+    public function testRunWithConstraints()
+    {
+        $this->melodyRun('hello-world-with-constraints.php');
+        $output = $this->melodyRun('hello-world-with-constraints.php');
         $this->assertSame('Hello world', $output);
     }
 
@@ -118,39 +144,20 @@ class IntegrationTest extends \PHPUnit_Framework_TestCase
         $this->assertContains('memory_limit=42M', $output);
     }
 
-    private function melodyRun($fixture, array $options = array())
+    protected function setUp()
     {
-        $melody = new Melody();
-
-        $filename = $this->getFixtureFile($fixture);
-
-        $options = array_replace(array(
-            'prefer_source' => false,
-            'no_cache' => false,
-        ), $options);
-
-        $configuration = new RunConfiguration($options['no_cache'], $options['prefer_source']);
-
-        $output = null;
-        $cliExecutor = function (Process $process, $useProcessHelper) use (&$output) {
-            $process->setTty(false);
-            $process->mustRun(function ($type, $text) use (&$output) {
-                $output .= $text;
-            });
-        };
-
-        $melody->run($filename, array(), $configuration, $cliExecutor);
-
-        return $output;
+        $this->fs = new Filesystem();
+        $this->cleanCache();
     }
 
     private function cleanCache()
     {
-        $this->fs->remove(sys_get_temp_dir().'/melody');
+        $this->fs->remove(sys_get_temp_dir() . '/melody');
     }
 
-    private function getFixtureFile($fixtureName)
+    protected function tearDown()
     {
-        return sprintf('%s/Integration/%s', __DIR__, $fixtureName);
+        $this->cleanCache();
+        $this->fs = null;
     }
 }

--- a/src/SensioLabs/Melody/Tests/IntegrationTest.php
+++ b/src/SensioLabs/Melody/Tests/IntegrationTest.php
@@ -45,13 +45,13 @@ class IntegrationTest extends \PHPUnit_Framework_TestCase
     {
         $this->melodyRun('hello-world.php');
         $output = $this->melodyRun('hello-world.php');
-        $this->assertContains('Hello world', $output);
+        $this->assertSame('Hello world', $output);
     }
 
     public function testRunWithConstraints()
     {
         $output = $this->melodyRun('hello-world-with-constraints.php');
-        $this->assertSame('Hello world', $output);
+        $this->assertContains('Hello world', $output);
     }
 
     public function testRunWithNoCache()

--- a/src/SensioLabs/Melody/Tests/IntegrationTest.php
+++ b/src/SensioLabs/Melody/Tests/IntegrationTest.php
@@ -50,7 +50,6 @@ class IntegrationTest extends \PHPUnit_Framework_TestCase
 
     public function testRunWithConstraints()
     {
-        $this->melodyRun('hello-world-with-constraints.php');
         $output = $this->melodyRun('hello-world-with-constraints.php');
         $this->assertSame('Hello world', $output);
     }


### PR DESCRIPTION
This PR give the possibility to do this:
```php
<?php
<<<CONFIG
packages:
    - "php: >=5.5.0"
    - "twig/twig: ~1.0"
    - "ext-soap: *"
CONFIG;
//...
```
Like this it can say to user to use the good php version and good extension that's a gist intend to work with.
I don't know if it's should be documented cause it's a default composer feature.