### PR TITLE
Fix Resource cannot be initialized without $metadata argument

### DIFF
--- a/src/SensioLabs/Melody/Resource/Metadata.php
+++ b/src/SensioLabs/Melody/Resource/Metadata.php
@@ -16,7 +16,7 @@ class Metadata
     private $revision;
     private $uri;
 
-    public function __construct($id, $owner, \DateTime $createdAd, \DateTime $updatedAt, $revision, $uri)
+    public function __construct($id = null, $owner = null, \DateTime $createdAd = null, \DateTime $updatedAt = null, $revision = null, $uri = null)
     {
         $this->id = $id;
         $this->owner = $owner;


### PR DESCRIPTION
[`Resource`](https://github.com/sensiolabs/melody/blob/master/src/SensioLabs/Melody/Resource/Resource.php#L16-L20)'s constructor says the metadata argument could be null. Then it'll create a new instance of `Metadata`without any argument... Yeah. Metadata's constructor does not allow that...

Building a `Resource` instance with empty metadata might be useful indeed, so I guess the incriminated constructor here is `Metadata`'s one.