### PR TITLE
Add GZ compression to box.json configuration.

### DIFF
--- a/box.json
+++ b/box.json
@@ -4,6 +4,7 @@
     "compactors": [
         "Herrera\\Box\\Compactor\\Php"
     ],
+    "compression": "GZ",
     "directories": ["src"],
     "files": [
         "LICENSE"


### PR DESCRIPTION
I would suggest to whomever is building the phar files to install the requirements with `composer install --no-dev`. The phar is packaged with a lot of phpunit code which takes a LOT of space.

melody.phar built with all dependencies (require + require-dev)
Without compression: 1208 KB
With compression: 348 KB

By only installing the dependencies (and not the require-dev dependencies), I went from 385 KB to 132 KB.

melody.phar built with only require dependencies
Without compression: 385 KB
With compression: 132 KB