### PR TITLE
Fix unreadable/writable tty

### DIFF
--- a/src/SensioLabs/Melody/Runner/Runner.php
+++ b/src/SensioLabs/Melody/Runner/Runner.php
@@ -7,6 +7,7 @@ use SensioLabs\Melody\Resource\Resource;
 use SensioLabs\Melody\Script\Script;
 use Symfony\Component\Process\PhpExecutableFinder;
 use Symfony\Component\Process\ProcessBuilder;
+use Symfony\Component\Process\Exception\RuntimeException;
 
 /**
  * Runner.
@@ -51,8 +52,11 @@ class Runner
             ->getProcess()
         ;
 
-        if (!defined('PHP_WINDOWS_VERSION_BUILD') && php_sapi_name() === 'cli') {
-            $process->setTty(true);
+        if (!defined('PHP_WINDOWS_VERSION_BUILD') && PHP_SAPI === 'cli') {
+            try {
+                $process->setTty(true);
+            } catch (RuntimeException $e) {
+            }
         }
 
         return $process;


### PR DESCRIPTION
Sometime the `/dev/tty` file is not readable and/or writable which let Symfony/Process throws an Exception.

This PR de-activate the call to setTty if the TTY mode is notavailable